### PR TITLE
Rename ThrottlePriority and ThrottleResult values, implement __str__ as values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="aio-throttle",
-    version="1.0.1",
+    version="1.1.0",
     author="Yury Pliner",
     author_email="yury.pliner@gmail.com",
     description="A simple throttling package",


### PR DESCRIPTION
The goal of the PR is to improve readability of the such enums in logs and metrics.